### PR TITLE
Stop re-rendering MaterialComponent every time game state changes

### DIFF
--- a/src/components/dialogs/RulesDialog/MaterialRulesDialogContent.tsx
+++ b/src/components/dialogs/RulesDialog/MaterialRulesDialogContent.tsx
@@ -59,7 +59,7 @@ export const MaterialRulesDialogContent = <P extends number = number, M extends 
   const { previous, next } = useMaterialNavigation(helpDisplay)
   if (!description) return null
   const item = helpDisplay.item
-  const { width, height } = description.getSize(item.id, context)
+  const { width, height } = description.getSize(item.id)
   const itemContext: ItemContext<P, M, L> = { ...context, type: helpDisplay.itemType, index: helpDisplay.itemIndex!, displayIndex: helpDisplay.displayIndex! }
   const hasNavigation = previous || next
   return <>

--- a/src/components/material/Dices/CubicDiceDescription.tsx
+++ b/src/components/material/Dices/CubicDiceDescription.tsx
@@ -23,7 +23,7 @@ export abstract class CubicDiceDescription<P extends number = number, M extends 
     return Array.isArray(this.images) ? this.images : this.images[itemId]
   }
 
-  getColor(_itemId: ItemId, _context: MaterialContext<P, M, L>) {
+  getColor(_itemId: ItemId) {
     return this.color
   }
 
@@ -31,14 +31,14 @@ export abstract class CubicDiceDescription<P extends number = number, M extends 
     return index
   }
 
-  content = ({ itemId, context, highlight, playDown }: MaterialContentProps<P, M, L, ItemId>) => {
+  content = ({ itemId, highlight, playDown }: MaterialContentProps<ItemId>) => {
     const internalMask = css`
       position: absolute;
       top: 1px;
       left: 1px;
       width: calc(${this.width}em - 2px);
       height: calc(${this.width}em - 2px);
-      background-color: ${this.getColor(itemId, context)};
+      background-color: ${this.getColor(itemId)};
       border-radius: ${this.borderRadius / 2}em;
     `
     return <>

--- a/src/components/material/FlatMaterial/FlatMaterial.tsx
+++ b/src/components/material/FlatMaterial/FlatMaterial.tsx
@@ -12,15 +12,15 @@ export abstract class FlatMaterialDescription<P extends number = number, M exten
   image?: string
   images?: Record<ItemId extends keyof any ? ItemId : never, string>
 
-  getImage(itemId: ItemId, context: MaterialContext<P, M, L>): string | undefined {
-    return this.images?.[this.getFrontId(itemId, context)] ?? this.image
+  getImage(itemId: ItemId): string | undefined {
+    return this.images?.[this.getFrontId(itemId)] ?? this.image
   }
 
   backImage?: string
   backImages?: Record<ItemId extends keyof any ? ItemId : never, string>
 
-  getBackImage(itemId: ItemId, context: MaterialContext<P, M, L>): string | undefined {
-    return this.backImages?.[this.getBackId(itemId, context)] ?? this.backImage
+  getBackImage(itemId: ItemId): string | undefined {
+    return this.backImages?.[this.getBackId(itemId)] ?? this.backImage
   }
 
   getImages(): string[] {
@@ -32,11 +32,11 @@ export abstract class FlatMaterialDescription<P extends number = number, M exten
     return images
   }
 
-  protected getFrontId(itemId: ItemId, _context: MaterialContext<P, M, L>) {
+  protected getFrontId(itemId: ItemId) {
     return typeof itemId === 'object' ? (itemId as any).front : itemId as keyof any
   }
 
-  protected getBackId(itemId: ItemId, _context: MaterialContext<P, M, L>) {
+  protected getBackId(itemId: ItemId) {
     return typeof itemId === 'object' ? (itemId as any).back : itemId as keyof any
   }
 
@@ -44,8 +44,8 @@ export abstract class FlatMaterialDescription<P extends number = number, M exten
     return !!this.backImage || !!this.backImages
   }
 
-  isFlipped(item: Partial<MaterialItem<P, L>>, context: MaterialContext<P, M, L>): boolean {
-    return this.hasBackFace() && this.getFrontId(item.id, context) === undefined
+  isFlipped(item: Partial<MaterialItem<P, L>>, _context: MaterialContext<P, M, L>): boolean {
+    return this.hasBackFace() && this.getFrontId(item.id) === undefined
   }
 
   getRotations(item: MaterialItem<P, L>, context: ItemContext<P, M, L>): string[] {
@@ -60,15 +60,15 @@ export abstract class FlatMaterialDescription<P extends number = number, M exten
     return 0
   }
 
-  content = ({ itemId, context, highlight, playDown, children }: MaterialContentProps<P, M, L, ItemId>) => {
-    const image = this.getImage(itemId, context)
-    const backImage = this.getBackImage(itemId, context)
-    const size = this.getSize(itemId, context)
-    const borderRadius = this.getBorderRadius(itemId, context)
+  content = ({ itemId, highlight, playDown, children }: MaterialContentProps<ItemId>) => {
+    const image = this.getImage(itemId)
+    const backImage = this.getBackImage(itemId)
+    const size = this.getSize(itemId)
+    const borderRadius = this.getBorderRadius(itemId)
     return <>
       <div css={[
         faceCss,
-        this.getFrontExtraCss(itemId, context),
+        this.getFrontExtraCss(itemId),
         sizeCss(size.width, size.height),
         image && [backgroundCss(image), shadowCss(image)],
         borderRadius && borderRadiusCss(borderRadius),
@@ -78,7 +78,7 @@ export abstract class FlatMaterialDescription<P extends number = number, M exten
       </div>
       {backImage && <div css={[
         faceCss,
-        this.getBackExtraCss(itemId, context),
+        this.getBackExtraCss(itemId),
         sizeCss(size.width, size.height),
         backgroundCss(backImage), shadowCss(backImage),
         borderRadius && borderRadiusCss(borderRadius),
@@ -88,11 +88,11 @@ export abstract class FlatMaterialDescription<P extends number = number, M exten
     </>
   }
 
-  getFrontExtraCss(_itemId: ItemId, _context: MaterialContext<P, M, L>): Interpolation<Theme> {
+  getFrontExtraCss(_itemId: ItemId): Interpolation<Theme> {
     return
   }
 
-  getBackExtraCss(_itemId: ItemId, _context: MaterialContext<P, M, L>): Interpolation<Theme> {
+  getBackExtraCss(_itemId: ItemId): Interpolation<Theme> {
     return
   }
 }

--- a/src/components/material/GameTable/ItemDisplay.tsx
+++ b/src/components/material/GameTable/ItemDisplay.tsx
@@ -25,17 +25,20 @@ export const ItemDisplay = forwardRef<HTMLDivElement, ItemDisplayProps>((
   const { locations, focusedIndexes } = getLocationsWithFocus(item, itemContext, focus)
   const focusedLocations = useMemo(() => focusedIndexes.map(index => locations[index]), [locations, focusedIndexes])
   const locator = context.locators[item.location.type] ?? centerLocator
-  return <MaterialComponent ref={mergeRefs([ref, isFocused ? addFocusRef : undefined])}
+  const description = context.material[type]
+  return <MaterialComponent ref={isFocused ? mergeRefs([ref, addFocusRef]) : ref}
                             type={type} itemId={item.id}
                             playDown={focus && !isFocused && !focusedIndexes.length}
-                            css={[pointerCursorCss, transformCss(...locator.transformItem(item, itemContext))]}
+                            css={[pointerCursorCss, transformCss(...locator.transformItem(item, itemContext)), description?.getItemExtraCss(item, itemContext)]}
                             {...props}>
-    {focusedLocations.length > 0 && <LocationsMask locations={focusedLocations}/>}
-    {locations.map((location, index) => {
-        const hasFocus = focusedIndexes.includes(index)
-        return <SimpleDropArea key={JSON.stringify(location)} location={location} alwaysVisible={hasFocus} ref={hasFocus ? addFocusRef : undefined}/>
-      }
-    )}
+    {locations.length > 0 && <>
+      {focusedLocations.length > 0 && <LocationsMask locations={focusedLocations}/>}
+      {locations.map((location, index) => {
+          const hasFocus = focusedIndexes.includes(index)
+          return <SimpleDropArea key={JSON.stringify(location)} location={location} alwaysVisible={hasFocus} ref={hasFocus ? addFocusRef : undefined}/>
+        }
+      )}
+    </>}
   </MaterialComponent>
 })
 

--- a/src/components/material/MaterialComponent.tsx
+++ b/src/components/material/MaterialComponent.tsx
@@ -1,9 +1,9 @@
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react'
-import { forwardRef, HTMLAttributes, MouseEvent, useMemo } from 'react'
+import { forwardRef, HTMLAttributes, memo, MouseEvent, useMemo } from 'react'
 import { LongPressCallbackReason, LongPressEventType, useLongPress } from 'use-long-press'
 import { sizeCss } from '../../css'
-import { useMaterialContext, useMaterialDescription } from '../../hooks'
+import { useMaterialDescription } from '../../hooks'
 import { combineEventListeners } from '../../utilities'
 
 export type MaterialComponentProps<M extends number = number, ItemId = any> = {
@@ -15,11 +15,10 @@ export type MaterialComponentProps<M extends number = number, ItemId = any> = {
   playDown?: boolean
 } & HTMLAttributes<HTMLElement>
 
-export const MaterialComponent = forwardRef<HTMLDivElement, MaterialComponentProps>((
-  { type, itemId, onShortClick, onLongClick, highlight, playDown , ...props }, ref
+export const MaterialComponent = memo(forwardRef<HTMLDivElement, MaterialComponentProps>((
+  { type, itemId, onShortClick, onLongClick, highlight, playDown, ...props }, ref
 ) => {
   const description = useMaterialDescription(type)
-  const context = useMaterialContext()
 
   const listeners = useLongPress(() => onLongClick && onLongClick(), {
     detect: LongPressEventType.Pointer,
@@ -33,18 +32,18 @@ export const MaterialComponent = forwardRef<HTMLDivElement, MaterialComponentPro
     filterEvents: event => !(event as MouseEvent).button // Ignore clicks on mouse buttons > 0
   })()
 
-  if (!description) return null // TODO: parent should never include a material component which description is missing at all
+  if (!description) return null
 
-  const { width, height } = description.getSize(itemId, context)
+  const { width, height } = description.getSize(itemId)
 
   const componentCss = useMemo(() => [materialCss, sizeCss(width, height)], [width, height])
 
   return (
     <div ref={ref} css={componentCss} {...props} {...combineEventListeners(listeners, props)}>
-      {description.content({ itemId, context, highlight, playDown, ...props })}
+      {description.content({ itemId, highlight, playDown, ...props })}
     </div>
   )
-})
+}))
 
 MaterialComponent.displayName = 'MaterialComponent'
 

--- a/src/components/material/MaterialDescription.tsx
+++ b/src/components/material/MaterialDescription.tsx
@@ -1,4 +1,5 @@
 /** @jsxImportSource @emotion/react */
+import { Interpolation, Theme } from '@emotion/react'
 import { isDeleteItem, isMoveItem, isRoll, isSelectItem, Location, MaterialHelpDisplay, MaterialItem, MaterialMove } from '@gamepark/rules-api'
 import { ComponentType, FC, HTMLAttributes } from 'react'
 import { ItemContext, MaterialContext } from '../../locators'
@@ -12,16 +13,15 @@ export type ComponentSize = {
   height: number
 }
 
-export type MaterialContentProps<P extends number = number, M extends number = number, L extends number = number, ItemId = any> = {
+export type MaterialContentProps<ItemId = any> = {
   itemId: ItemId,
-  context: MaterialContext<P, M, L>,
   highlight?: boolean
   playDown?: boolean
 } & HTMLAttributes<HTMLElement>
 
 export abstract class MaterialDescription<P extends number = number, M extends number = number, L extends number = number, ItemId = any> {
   help?: ComponentType<MaterialHelpProps<P, M, L>>
-  abstract content: FC<MaterialContentProps<P, M, L, ItemId>>
+  abstract content: FC<MaterialContentProps<ItemId>>
   isMobile = false
 
   staticItem?: MaterialItem<P, L>
@@ -61,14 +61,14 @@ export abstract class MaterialDescription<P extends number = number, M extends n
   ratio?: number
   borderRadius?: number
 
-  getSize(_itemId: ItemId, _context: MaterialContext<P, M, L>): ComponentSize {
+  getSize(_itemId: ItemId): ComponentSize {
     if (this.width && this.height) return { width: this.width, height: this.height }
     if (this.ratio && this.width) return { width: this.width, height: this.width / this.ratio }
     if (this.ratio && this.height) return { width: this.height * this.ratio, height: this.height }
     throw new Error('You must implement 2 of "width", "height" & "ratio" in any Material description')
   }
 
-  getBorderRadius(_itemId: ItemId, _context: MaterialContext<P, M, L>): number | undefined {
+  getBorderRadius(_itemId: ItemId): number | undefined {
     return this.borderRadius
   }
 
@@ -82,6 +82,10 @@ export abstract class MaterialDescription<P extends number = number, M extends n
 
   getRotations(_item: MaterialItem<P, L>, _context: ItemContext<P, M, L>): string[] {
     return []
+  }
+
+  getItemExtraCss(_item: MaterialItem<P, L>, _context: ItemContext<P, M, L>): Interpolation<Theme> {
+    return
   }
 }
 

--- a/src/components/material/Writing/WritingDescription.tsx
+++ b/src/components/material/Writing/WritingDescription.tsx
@@ -3,7 +3,7 @@ import { css } from '@emotion/react'
 import { MaterialItem } from '@gamepark/rules-api'
 import { ReactNode } from 'react'
 import { backgroundCss, borderRadiusCss, shadowCss, shadowEffect, shineEffect, sizeCss } from '../../../css'
-import { ItemContext, MaterialContext } from '../../../locators'
+import { ItemContext } from '../../../locators'
 import { MaterialContentProps, MaterialDescription } from '../MaterialDescription'
 
 export abstract class WritingDescription<P extends number = number, M extends number = number, L extends number = number, ItemId = any>
@@ -12,8 +12,8 @@ export abstract class WritingDescription<P extends number = number, M extends nu
   image?: string
   images?: Record<ItemId extends keyof any ? ItemId : never, string>
 
-  getImage(itemId: ItemId, context: MaterialContext<P, M, L>): string | undefined {
-    return this.images?.[this.getFrontId(itemId, context)] ?? this.image
+  getImage(itemId: ItemId): string | undefined {
+    return this.images?.[this.getFrontId(itemId)] ?? this.image
   }
 
   getImages(): string[] {
@@ -23,11 +23,11 @@ export abstract class WritingDescription<P extends number = number, M extends nu
     return images
   }
 
-  protected getFrontId(itemId: ItemId, _context: MaterialContext<P, M, L>) {
+  protected getFrontId(itemId: ItemId) {
     return typeof itemId === 'object' ? (itemId as any).front : itemId as keyof any
   }
 
-  getFrontContent(_itemId: ItemId, _context: MaterialContext<P, M, L>): ReactNode | undefined {
+  getFrontContent(_itemId: ItemId): ReactNode | undefined {
     return
   }
 
@@ -42,10 +42,10 @@ export abstract class WritingDescription<P extends number = number, M extends nu
     return 0
   }
 
-  content = ({ itemId, context, highlight, playDown }: MaterialContentProps<P, M, L, ItemId>) => {
-    const image = this.getImage(itemId, context)
-    const size = this.getSize(itemId, context)
-    const borderRadius = this.getBorderRadius(itemId, context)
+  content = ({ itemId, highlight, playDown }: MaterialContentProps<ItemId>) => {
+    const image = this.getImage(itemId)
+    const size = this.getSize(itemId)
+    const borderRadius = this.getBorderRadius(itemId)
     return <div css={[
       faceCss,
       sizeCss(size.width, size.height),
@@ -53,7 +53,7 @@ export abstract class WritingDescription<P extends number = number, M extends nu
       borderRadius && borderRadiusCss(borderRadius),
       highlight ? shineEffect : playDown && playDownCss(image)
     ]}>
-      {this.getFrontContent(itemId, context)}
+      {this.getFrontContent(itemId)}
     </div>
   }
 }

--- a/src/locators/ItemLocator.tsx
+++ b/src/locators/ItemLocator.tsx
@@ -46,7 +46,7 @@ export class ItemLocator<P extends number = number, M extends number = number, L
     const parentMaterial = this.parentItemType ? context.material[this.parentItemType] : undefined
     if (parentMaterial) {
       const positionOnParent = this.getPositionOnParent(item.location, context)
-      const { width, height } = parentMaterial.getSize(this.getParentItemId(item.location), context)
+      const { width, height } = parentMaterial.getSize(this.getParentItemId(item.location))
       x += width * (positionOnParent.x - 50) / 100
       y += height * (positionOnParent.y - 50) / 100
     }


### PR DESCRIPTION
- Au niveau MaterialComponent, les customisations qui dépendent de l'état de la partie ne sont plus admises (le matériel est indépendant de l'état de la partie).
- Au niveau ItemDisplay, le css peut être modifié selon l'état de la partie : par exemple, sur Trek12, on peut mettre le cadre jaune autour du plateau du joueur avec getItemExtraCss (au lieu de getFrontExtraCss)