### PR TITLE
ElevationConfig.landAt for flat-landing trajectories

### DIFF
--- a/src/components/material/animations/ItemAnimations.ts
+++ b/src/components/material/animations/ItemAnimations.ts
@@ -79,9 +79,24 @@ export class ItemAnimations<P extends number = number, M extends number = number
     animation: Animation<ItemMove<P, M, L>>,
     context: ItemContextWithTrajectory<P, M, L, R, V>
   ) {
-    const waypoints = context.trajectory?.waypoints ?? []
+    // Waypoints that only carry elevation (no locator, no coordinates, no
+    // offset, no rotation, no easing) don't constrain the X/Y motion — they
+    // live on the parent div's elevation arc only. Filter them out here so
+    // the child div keeps its native simple keyframes path: a single CSS
+    // transition from origin to target with browser-tweened rotateY for
+    // free. Mixing in a midway keyframe with only elevation info forces the
+    // path through getTrajectoryKeyframes' interpolation routine and turns
+    // the smooth tween into a multi-step keyframes sequence (visible as a
+    // pause/saccade in browsers that snap between transform formats).
+    const waypoints = (context.trajectory?.waypoints ?? []).filter(w =>
+      w.locator !== undefined
+      || w.coordinates !== undefined
+      || w.offset !== undefined
+      || w.rotation !== undefined
+      || w.easing !== undefined
+    )
 
-    // If no waypoints, use simple keyframes
+    // If no waypoints constrain motion, use simple keyframes
     if (waypoints.length === 0) {
       return this.getTransformKeyframes(originTransforms.join(' '), targetTransforms.join(' '), animation, context)
     }
@@ -138,22 +153,32 @@ export class ItemAnimations<P extends number = number, M extends number = number
         const locatorTransforms = locator.placeItem(fakeItem, context)
         transforms.push('translate(-50%, -50%)')
         transforms.push(...locatorTransforms)
-      } else if (t === 0 && !waypoint) {
-        transforms.push(...originTransforms)
-      } else if (t === 1 && !waypoint) {
-        transforms.push(...targetTransforms)
       } else {
-        // Build interpolated transforms
+        // Build interpolated transforms — used for every non-locator keyframe
+        // INCLUDING the implicit t=0 and t=1 frames. Using the same transform
+        // shape everywhere ("translate(-50%, -50%) translate3d() rotateZ()
+        // rotateY()") avoids the CSS matrix-lerp glitch we'd hit if some
+        // keyframes were originTransforms verbatim (which may omit rotateY
+        // when the card is face-up) and others were the interpolated build:
+        // browsers cannot lerp between an N-transform string and a different
+        // N+1-transform string without snapping. Keep the format stable.
         transforms.push('translate(-50%, -50%)')
         transforms.push(`translate3d(${x}em, ${y}em, ${z}em)`)
 
-        // Interpolate rotation if present
-        const originRotation = extractRotation(originTransforms)
-        const targetRotation = extractRotation(targetTransforms)
-        if (originRotation !== undefined || targetRotation !== undefined) {
-          const rotation = interpolateCoordinate(originRotation ?? 0, targetRotation ?? 0, t)
-          if (rotation !== 0) {
-            transforms.push(`rotateZ(${rotation}deg)`)
+        const originRotateZ = extractRotation(originTransforms)
+        const targetRotateZ = extractRotation(targetTransforms)
+        if (originRotateZ !== undefined || targetRotateZ !== undefined) {
+          const rotateZ = interpolateCoordinate(originRotateZ ?? 0, targetRotateZ ?? 0, t)
+          if (rotateZ !== 0) {
+            transforms.push(`rotateZ(${rotateZ}deg)`)
+          }
+        }
+        const originRotateY = extractRotateY(originTransforms)
+        const targetRotateY = extractRotateY(targetTransforms)
+        if (originRotateY !== undefined || targetRotateY !== undefined) {
+          const rotateY = interpolateCoordinate(originRotateY ?? 0, targetRotateY ?? 0, t)
+          if (rotateY !== 0) {
+            transforms.push(`rotateY(${rotateY}deg)`)
           }
         }
       }
@@ -202,8 +227,22 @@ export class ItemAnimations<P extends number = number, M extends number = number
     if (elevationConfig !== false) {
       const resolvedElevation = elevationConfig ?? defaultElevation
       const elevationArc = getElevationKeyframes(resolvedElevation)
+      // `infinite` is the legacy default — keeps two same-duration animations
+      // chained back to back from sharing a frozen frame (cf. Romain's
+      // 2026-03-16 fix). It's harmless for the classic arc since its 0% and
+      // 100% keyframes are identical, so cycle 2 begins right where cycle 1
+      // ended (translateZ(0)) — no visible discontinuity.
+      //
+      // When `landAt` is set, the arc holds 0 from landAt to 100% but cycle 2
+      // restarts the rise to peak — visible as a rebound at the very tail of
+      // the trajectory if the component lingers past `duration`. Switching to
+      // `forwards` for those cases freezes the final 0 keyframe and removes
+      // the rebound. The trade-off (potential chained-animation glitch) is
+      // worth it because callers opt into `landAt` precisely to control how
+      // the card lands — they don't want the lift to come back.
+      const fillMode = resolvedElevation.landAt === undefined ? 'infinite' : 'forwards'
       return css`
-        animation: ${elevationArc} ${duration}s linear infinite;
+        animation: ${elevationArc} ${duration}s linear ${fillMode};
         > * {
           animation: ${animationKeyframes} ${duration}s ${easing} forwards;
         }
@@ -296,3 +335,27 @@ function extractRotation(transforms: string[]): number | undefined {
   }
   return undefined
 }
+
+/**
+ * Parse a transform string array and extract the rotateY angle in degrees.
+ * Mirrors {@link extractRotation} for the face-flip axis — used so that
+ * intermediate waypoints in a trajectory preserve a card's face-up /
+ * face-down state via linear interpolation instead of dropping the
+ * rotateY transform entirely (which would snap the card back to face-up
+ * at every waypoint).
+ */
+function extractRotateY(transforms: string[]): number | undefined {
+  for (const transform of transforms) {
+    const rotateYMatch = transform.match(/rotateY\(\s*([-\d.]+)(deg|rad|turn)?\s*\)/)
+    if (rotateYMatch) {
+      const value = parseFloat(rotateYMatch[1])
+      const unit = rotateYMatch[2] || 'deg'
+      if (unit === 'rad') return value * (180 / Math.PI)
+      if (unit === 'turn') return value * 360
+      return value
+    }
+  }
+  return undefined
+}
+
+

--- a/src/components/material/animations/Trajectory.ts
+++ b/src/components/material/animations/Trajectory.ts
@@ -11,7 +11,7 @@ export interface ElevationConfig {
    * Maximum height of the arc in em units.
    * @default 10
    */
-  height: number
+  height?: number
 
   /**
    * Position of the peak in the animation (0-1).
@@ -26,6 +26,15 @@ export interface ElevationConfig {
    * - 'ease': uses CSS ease timing for smoother feel
    */
   curve?: 'parabolic' | 'linear' | 'ease'
+
+  /**
+   * Position at which the arc returns to 0 (0-1). After this point the
+   * elevation stays at 0 for the rest of the animation — useful when the
+   * card needs to slide flat for its final approach (e.g. landing under a
+   * deck stack instead of dropping from above).
+   * @default 1
+   */
+  landAt?: number
 }
 
 /**
@@ -140,7 +149,7 @@ export const defaultElevation: ElevationConfig = {
 export function calculateElevation(t: number, config: ElevationConfig | false | undefined): number {
   if (config === false) return 0
 
-  const { height, peak = 0.5, curve = 'parabolic' } = config ?? defaultElevation
+  const { height = 10, peak = 0.5, curve = 'parabolic' } = config ?? defaultElevation
 
   if (curve === 'linear') {
     // Triangular arc
@@ -201,12 +210,42 @@ export function extractTranslation(transforms: string[]): Coordinates {
 
 /**
  * Generate simple elevation keyframes for the parent div.
- * Creates a 3-keyframe arc: from (0) → peak (height) → to (0).
+ *
+ * Default behaviour (when `landAt` is omitted): a 3-keyframe arc — `from, to`
+ * at translateZ(0) with a single `peak%` at `translateZ(height em)`. This is
+ * the legacy shape; not touching it keeps every existing animation pixel-
+ * perfect identical.
+ *
+ * When `landAt` is provided (must be in (0, 1)): a 4-keyframe arc — rises to
+ * peak, descends back to 0 at `landAt`, then holds 0 until the end. Lets the
+ * card slide flat for its final approach (e.g. landing under a deck stack).
  */
 export function getElevationKeyframes(config: ElevationConfig): ReturnType<typeof keyframes> {
-  const { height, peak = 0.5 } = config
+  const { height = 10, landAt } = config
+  if (landAt === undefined) {
+    const peak = config.peak ?? 0.5
+    const peakPercent = Math.round(peak * 100)
+    const frames = `from, to { transform: translateZ(0); } ${peakPercent}% { transform: translateZ(${height}em); }`
+    return keyframes`${frames}`
+  }
+  // landAt mode: peak must sit strictly between 0 and landAt so the arc has
+  // room to rise AND descend before the flat-landing plateau. When the caller
+  // doesn't supply a peak we centre it inside [0, landAt]; if they pass a
+  // peak >= landAt (legacy default 0.5 with landAt = 0.4 would land here),
+  // we recentre too — otherwise the keyframe percentages collide and the
+  // arc culminates AFTER landAt, defeating the flat plateau.
+  const peak = config.peak !== undefined && config.peak < landAt ? config.peak : landAt / 2
   const peakPercent = Math.round(peak * 100)
-  const frames = `from, to { transform: translateZ(0); } ${peakPercent}% { transform: translateZ(${height}em); }`
+  const landPercent = Math.round(landAt * 100)
+  // Spell out the 100% keyframe explicitly. Combining `${landPercent}%, to`
+  // in a single selector ought to apply translateZ(0) at both points, but
+  // some CSS parsers in the @emotion stack treat the comma-joined selector
+  // as overriding only the first point (landPercent) and leave 100% to be
+  // interpolated back to the peak via the looping `infinite` we run the
+  // arc on — visible as a tiny rebound at the very end of the trajectory.
+  // Two separate keyframes at landPercent% and 100% pin both points and
+  // avoid the rebound.
+  const frames = `from { transform: translateZ(0); } ${peakPercent}% { transform: translateZ(${height}em); } ${landPercent}% { transform: translateZ(0); } to { transform: translateZ(0); }`
   return keyframes`${frames}`
 }
 


### PR DESCRIPTION
Add an optional landAt field to ElevationConfig (and a 4-keyframe arc in getElevationKeyframes) so a trajectory can hold elevation 0 from a chosen point to the end. Useful when a card must slide flat for its final approach (e.g. land under a deck stack instead of dropping from above).

Switch the parent-div fill-mode to forwards when landAt is set: the legacy infinite mode would otherwise restart the rise-to-peak right after the trajectory ends and leak a visible rebound. The classic 3-keyframe arc keeps infinite (its 0% and 100% frames are identical, so looping is invisible and preserves Romain's 2026-03-16 chained-animation fix).

Filter purely-elevation waypoints out of the child div's X/Y keyframe path: they live on the parent arc only, and forcing them through the keyframe interpolation would split the smooth CSS tween into segments with ease-in-out re-applied per segment, producing a visible pause/saccade at the join.

Add a unified transform shape (translate3d + optional rotateZ + optional rotateY) on every interpolated keyframe so browsers can lerp without the matrix-mismatch glitch they hit when adjacent keyframes have different transform-list lengths. extractRotateY mirrors extractRotation so an intermediate locator/coordinate waypoint preserves the face-up/face-down state instead of dropping the rotateY transform.